### PR TITLE
Push JSON dependency to ~>2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.2.0 [August 2, 2017]
+* Bump JSON dependency to ~> 2.0 for Ruby 2.4 compatibility
+
 ### 1.1.0 [November 3, 2016]
 * Added support for pipeline API parameter
 

--- a/docraptor.gemspec
+++ b/docraptor.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license     = "Apache-2.0"
 
   s.add_runtime_dependency 'typhoeus', '~> 0.2', '>= 0.2.1'
-  s.add_runtime_dependency 'json', '~> 1.4', '>= 1.4.6'
+  s.add_runtime_dependency 'json', '~> 2.0'
 
   s.add_development_dependency 'pry', '~> 0.10', '>= 0.10.3'
   s.add_development_dependency 'rake', '~> 10.4', '>= 10.4.2'

--- a/lib/docraptor/version.rb
+++ b/lib/docraptor/version.rb
@@ -1,3 +1,3 @@
 module DocRaptor
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end

--- a/swagger-config.json
+++ b/swagger-config.json
@@ -1,5 +1,5 @@
 {
 	"gemName": "docraptor",
 	"moduleName": "DocRaptor",
-  "gemVersion": "1.1.0"
+  "gemVersion": "1.2.0"
 }


### PR DESCRIPTION
Hi guys,

I'm trying to update gems in our project to be able to use the new default JSON (2.0.2) in Ruby 2.4.1 and docraptor-ruby had it locked to 1.x. This is just a quick PR to push that up to 2.0 and allow it to work more easily with other 2.4-ready gems.

Let me know if there's anything I can change here!

I ran all tests locally with ruby 2.4.1 and json ~> 2.0 and it didn't have any issues (output in comment below).

Thanks!