### PR TITLE
Uses Addressable::URI.encode instead of URI.encode, which is removed in Ruby > 2.7

### DIFF
--- a/docraptor.gemspec
+++ b/docraptor.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.required_ruby_version = ">= 1.9"
 
+  s.add_runtime_dependency 'addressable', '~> 2.7.0'
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
 

--- a/lib/docraptor/api_client.rb
+++ b/lib/docraptor/api_client.rb
@@ -15,7 +15,7 @@ require 'json'
 require 'logger'
 require 'tempfile'
 require 'typhoeus'
-require 'uri'
+require 'addressable/uri'
 
 module DocRaptor
   class ApiClient
@@ -266,7 +266,7 @@ module DocRaptor
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode(@config.base_url + path)
+      Addressable::URI.encode(@config.base_url + path)
     end
 
     # Builds the HTTP request body

--- a/lib/docraptor/configuration.rb
+++ b/lib/docraptor/configuration.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.4.14
 
 =end
 
-require 'uri'
+require 'addressable/uri'
 
 module DocRaptor
   class Configuration
@@ -175,7 +175,7 @@ module DocRaptor
 
     def base_url
       url = "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
-      URI.encode(url)
+      Addressable::URI.encode(url)
     end
 
     # Gets API key (with prefix if set).


### PR DESCRIPTION
This adds a new dependency `addressable`, but this seems to be pretty common solution for other open source libraries, see https://github.com/auth0/ruby-auth0/pull/240/files.

Fixes https://github.com/DocRaptor/docraptor-ruby/issues/22