### PR TITLE
Proxy options added

### DIFF
--- a/lib/docraptor/api_client.rb
+++ b/lib/docraptor/api_client.rb
@@ -111,6 +111,8 @@ module DocRaptor
         :sslcert => @config.cert_file,
         :sslkey => @config.key_file,
         :verbose => @config.debugging,
+        :proxy => @config.proxy,
+        :proxyuserpwd => @config.proxyuserpwd,
         :followlocation => follow_location
       }
 

--- a/lib/docraptor/api_client.rb
+++ b/lib/docraptor/api_client.rb
@@ -115,6 +115,7 @@ module DocRaptor
         :proxyuserpwd => @config.proxyuserpwd,
         :followlocation => follow_location
       }
+      @config.logger.debug "req_opts\n#{req_opts}\n~END~\n"
 
       # set custom cert, if provided
       req_opts[:cainfo] = @config.ssl_ca_cert if @config.ssl_ca_cert

--- a/lib/docraptor/api_client.rb
+++ b/lib/docraptor/api_client.rb
@@ -115,7 +115,6 @@ module DocRaptor
         :proxyuserpwd => @config.proxyuserpwd,
         :followlocation => follow_location
       }
-      @config.logger.debug "req_opts\n#{req_opts}\n~END~\n"
 
       # set custom cert, if provided
       req_opts[:cainfo] = @config.ssl_ca_cert if @config.ssl_ca_cert

--- a/lib/docraptor/configuration.rb
+++ b/lib/docraptor/configuration.rb
@@ -133,6 +133,16 @@ module DocRaptor
     # https://github.com/typhoeus/ethon/blob/master/lib/ethon/easy/queryable.rb#L96
     attr_accessor :params_encoding
 
+    # Proxy URL to pass to Typhoeus.
+    # Default to nil.
+    attr_accessor :proxy
+
+    # Proxy username & password to pass to Typhoeus.
+    # Format as `username:password`.
+    #
+    # Default to nil.
+    attr_accessor :proxyuserpwd
+
 
     attr_accessor :inject_format
 
@@ -155,6 +165,8 @@ module DocRaptor
       @key_file = nil
       @timeout = 0
       @params_encoding = nil
+      @proxy = nil
+      @proxyuserpwd = nil
       @debugging = false
       @inject_format = false
       @force_ending_format = false


### PR DESCRIPTION
Why is this change needed?
--------------------------
The library could not be used behind a proxy/firewall previously.

How does it address the issue?
------------------------------
Adds a config option for proxy details, this aligns with the options for Typhoeus

Any links to any relevant tickets, articles, or other resources?
---------------------------------------------------------------

Any screenshots?
----------------

Did you complete all of the following?
--------------------------------------
No tests run (as I had an error with Docker trying to run locally), should not be necessary as it's a simple config additional and uses the same pattern as existing config options.
